### PR TITLE
fix: ci script 수정 및 webpack에서 node_env exports 구문 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,6 @@ jobs:
 
       - name: build page
         run: yarn run build
-
-      - name: start page
-        run: yarn run start
         env:
           MONGODB_URL: ${{ secrets.MONGODB_URL }}
           DB_NAME: ${{ secrets.DB_NAME }}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,11 @@
+const webpack = require("webpack");
+
+module.exports = {
+  plugins: [
+    new webpack.DefinePlugin({
+      "process.env.MONGO_URL": JSON.stringify(process.env.MONGO_URL),
+      "process.env.DEV_URL": JSON.stringify(process.env.DEV_URL),
+      "process.env.DB_NAME": JSON.stringify(process.env.DB_NAME),
+    }),
+  ],
+};


### PR DESCRIPTION
- ($deploy.yml): yarn run start 구문 삭제
- webpack.config.js 추가