### PR TITLE
Hotfix: SEO 및 sitemap 수정

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -4,12 +4,12 @@ module.exports = {
   siteUrl: process.env.DEV_URL,
   generateRobotsTxt: true,
   changefreq: "weekly",
-  exclude: ["/api/**/*.ts", "/write.tsx, /server-sitemap.xml"],
+  exclude: ["/api/**/*.ts", "/admin/*.tsx"],
   robotsTxtOptions: {
     policies: [
       {
         userAgent: "*",
-        disallow: ['/api/**/*.ts", "/write.tsx'],
+        disallow: ["/api/**/*.ts", "/admin/*.tsx"],
       },
       { userAgent: "*", allow: "/" },
     ],

--- a/pages/api/posts.ts
+++ b/pages/api/posts.ts
@@ -74,7 +74,13 @@ async function getPosts(req: any, res: any) {
     // connect to the database
     let { db } = await connectToDatabase();
     const options = {
-      projection: { images: 0 },
+      projection: {
+        images: 0,
+        thumbnails: 0,
+        isThumbnail: 0,
+        series: 0,
+        imageTitle: 0,
+      },
     };
     // fetch the posts
     let posts = await db

--- a/pages/posts/[title].tsx
+++ b/pages/posts/[title].tsx
@@ -6,9 +6,6 @@ import { useEffect } from "react";
 
 export default function Post({ data }: any) {
   let imgUrl = "/default_thumbnail.svg";
-  if (data.post[0].thumbnail != null) {
-    imgUrl = `data:image/${data.post[0].thumbnail.contentType};base64,${data.post[0].thumbnail.data};`;
-  }
   const title = data.post[0].title;
   const url = `https://www.chocoham.dev/posts/${data.post[0].title}`;
   const description =

--- a/seo.config.js
+++ b/seo.config.js
@@ -1,14 +1,14 @@
 const url = "https://chocoham.dev/";
 
 const SEO = {
-  title: `초코햄의 블로그`,
+  title: `Chocoham | 초코햄의 블로그`,
   description: "그림과 코딩을 좋아하는 프론트엔드 개발자 ChocoHam의 블로그",
   canonical: url,
   openGraph: {
     type: "website",
     locale: "utf-8",
     url: url,
-    title: "초코햄의 블로그",
+    title: "Chocoham | 초코햄의 블로그",
     description: "그림과 코딩을 좋아하는 프론트엔드 개발자 ChocoHam의 블로그",
     images: [
       {
@@ -18,7 +18,7 @@ const SEO = {
         alt: "default Thumbnail",
       },
     ],
-    site_name: "초코햄의 블로그",
+    site_name: "Chocoham | 초코햄의 블로그",
   },
   twitter: {
     handle: "@handle",


### PR DESCRIPTION
- 블로그의 default title 변경
- /admin/*.tsx 색인 검색 disallow로 변경
- SEO에 불필요한 속성 검색하지 않도록 쿼리문 수정